### PR TITLE
Lahjoitin-11 change brand name

### DIFF
--- a/fame-lahjoitukset.php
+++ b/fame-lahjoitukset.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Fame\WordPress\Lahjoitukset\Plugin;
 
 /**
- * Plugin Name:       Fame lahjoitukset
+ * Plugin Name:       Lahjoitin
  * Description:       Wordpress plugin for Fame lahjoitukset system.
  * Version:           1.x
  * Requires at least: 6.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "fame-lahjoitukset",
+	"name": "lahjoitin",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "fame-lahjoitukset",
+			"name": "lahjoitin",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "fame-lahjoitukset",
+	"name": "lahjoitin",
 	"version": "1.0.0",
 	"description": "Wordpress plugin for lahjoitukset backend.",
 	"author": "Fame Helsinki",

--- a/readme.txt
+++ b/readme.txt
@@ -10,7 +10,7 @@ Wordpress plugin for Fame lahjoitukset backend.
 
 == Description ==
 
-Lahjoitin is a WordPress plugin that provides a Gutenberg block for adding a donation form to your website. It is part of the Lahjoitin.fi donation platform, developed by Fame, and integrates seamlessly into WordPress to support easy and accessible online donations.
+Lahjoitin is a WordPress plugin that provides a Gutenberg block for adding a donation form to your website. It is part of the Lahjoitin.fi donation platform, developed by Fame, and integrates into WordPress to support easy and accessible online donations.
 
 👉 Learn more at [Lahjoitin.fi](https://lahjoitin.fi)
 

--- a/readme.txt
+++ b/readme.txt
@@ -10,7 +10,9 @@ Wordpress plugin for Fame lahjoitukset backend.
 
 == Description ==
 
-This block adds support for Fame donation system.
+Lahjoitin is a WordPress plugin that provides a Gutenberg block for adding a donation form to your website. It is part of the Lahjoitin.fi donation platform, developed by Fame, and integrates seamlessly into WordPress to support easy and accessible online donations.
+
+👉 Learn more at [Lahjoitin.fi](https://lahjoitin.fi)
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Fame Lahjoitukset ===
+=== Lahjoitin ===
 Contributors:      Fame Helsinki
 Tags:              block
 Tested up to:      6.7
@@ -14,7 +14,7 @@ This block adds support for Fame donation system.
 
 == Installation ==
 
-1. Upload the plugin files to the `/wp-content/plugins/lahjoitukset` directory, or install the plugin through the WordPress plugins screen directly.
+1. Upload the plugin files to the `/wp-content/plugins/wp-lahjoitukset` directory, or install the plugin through the WordPress plugins screen directly.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Frequently Asked Questions ==

--- a/src/Blocks/donation-form/block.json
+++ b/src/Blocks/donation-form/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"name": "famehelsinki/donation-form",
 	"version": "0.1.0",
-	"title": "Donation form",
+	"title": "Lahjoitin",
 	"category": "widgets",
 	"description": "Gutenberg block for Fame donation system.",
 	"example": {},

--- a/templates/error-reinstall.php
+++ b/templates/error-reinstall.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 ?>
 <div class="error below-h2">
-    <p><?php esc_html_e('The Fame Lahjoitukset plugin is installed incorrectly, please re-install', 'fame_lahjoitukset'); ?></p>
+    <p><?php esc_html_e('The Lahjoitin plugin is installed incorrectly, please re-install', 'fame_lahjoitukset'); ?></p>
 </div>


### PR DESCRIPTION
Vaihdoin nimen pluginille ja Gutenberg blokille ja readme-fileen, mutta en vaihtanut esim. fame-lahjoitukset.php nimeä enkä niitä missä se oli aika monessa paikkaa kuten fame_lahjoitukset.pot tiedostossa. Pitääkö nimi wp-lahjoitukset gitissä  myös vaihtaa? jotta pluginin nimi on myös koodissa lahjoitin. Olisiko se lahjoitin vai wp-lahjoitin?

Closes #11 